### PR TITLE
update flake8-docstrings to minimum version of 1.5.0

### DIFF
--- a/project-templates/python/{{cookiecutter.github_name}}/tox.ini
+++ b/project-templates/python/{{cookiecutter.github_name}}/tox.ini
@@ -153,17 +153,9 @@ deps =
     flake8-print>=3.1.0
     flake8-bugbear
     flake8-breakpoint
-    # flake8-docstrings is broken for now
-    # using pydocstyle directly instead
-    # https://github.com/aws/aws-encryption-sdk-python/issues/173
-    # flake8-docstrings
-    pydocstyle
+    flake8-docstrings>=1.5.0
 commands =
     flake8 \
-        src/{{cookiecutter.module_name}}/ \
-        setup.py \
-        doc/conf.py
-    pydocstyle \
         src/{{cookiecutter.module_name}}/ \
         setup.py \
         doc/conf.py
@@ -184,8 +176,6 @@ basepython = {[testenv:flake8]basepython}
 deps = {[testenv:flake8]deps}
 commands =
     flake8 \
-        examples/src/
-    pydocstyle \
         examples/src/
     flake8 \
         # Ignore F811 redefinition errors in tests (breaks with pytest-mock use)


### PR DESCRIPTION
*Description of changes:*
update flake8-docstrings to minimum version of 1.5.0 to address compatibility issues with pydocstyle 4.x


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
