### PR TITLE
docs: simplify copyright header in Python project template

### DIFF
--- a/project-templates/python/cookiecutter.json
+++ b/project-templates/python/cookiecutter.json
@@ -24,6 +24,6 @@
     "license": ["Apache 2.0"],
     "derived": {
         "github_url": "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.github_name}}",
-        "copyright_notice": "# Copyright {% now 'utc', '%Y'%} Amazon.com, Inc. or its affiliates. All Rights Reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\"). You\n# may not use this file except in compliance with the License. A copy of\n# the License is located at\n#\n# http://aws.amazon.com/apache2.0/\n#\n# or in the \"license\" file accompanying this file. This file is\n# distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF\n# ANY KIND, either express or implied. See the License for the specific\n# language governing permissions and limitations under the License."
+        "copyright_notice": "# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.\n# SPDX-License-Identifier: Apache-2.0"
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

related to #15 

*Description of changes:*

As discussed in #15, we have a much simpler and lower maintenance copyright header that we can use now. This updates our Python project template to use that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
