### PR TITLE
chore: fix source-build-check in Python template

### DIFF
--- a/getting-started/python/README.md
+++ b/getting-started/python/README.md
@@ -77,7 +77,7 @@ and how to get started developing on these projects.
 ### Linux/MacOS
 
 For local development,
-we recommend using [`pyenv`][https://github.com/pyenv/pyenv].
+we recommend using [`pyenv`](https://github.com/pyenv/pyenv).
 If you want to quickly bootstrap a local development environment,
 run:
 

--- a/project-templates/python/{{cookiecutter.github_name}}/test/source-build-check.sh
+++ b/project-templates/python/{{cookiecutter.github_name}}/test/source-build-check.sh
@@ -3,20 +3,26 @@
 #
 # NOTE: Humans should not run this file directly. If you want to run this check, run "tox -e sourcebuildcheck".
 
-WORKINGDIR=$1
-DISTDIR=$2
+WORKINGDIR=${1}
+DISTDIR=${2}
+
+echo "Performing source build check"
+echo "Using working directory ${WORKINGDIR}"
+echo "Using dist directory ${DISTDIR}"
 
 echo "Locating the source build and copying it into the working directory."
 DISTFILE=`ls $DISTDIR/{{cookiecutter.pypi_name}}-*.tar.gz | tail -1`
-cp $DISTFILE $WORKINGDIR
-DISTFILE=`ls $WORKINGDIR/{{cookiecutter.pypi_name}}-*.tar.gz | tail -1`
+echo "Found source build at ${DISTFILE}"
+cp ${DISTFILE} ${WORKINGDIR}
 
 echo "Extracting the source build."
-cd $WORKINGDIR
-tar xzvf $DISTFILE
-rm $DISTFILE
-EXTRACTEDDIR=`ls | tail -1`
-cd $EXTRACTEDDIR
+cd ${WORKINGDIR}
+NEWDISTFILE=$(ls {{cookiecutter.pypi_name}}-*.tar.gz | tail -1)
+echo "Using distfile ${NEWDISTFILE}"
+tar xzvf ${NEWDISTFILE}
+rm ${NEWDISTFILE}
+EXTRACTEDDIR=$(ls | tail -1)
+cd ${EXTRACTEDDIR}
 
 echo "Installing requirements from extracted source build."
 pip install -r test/requirements.txt


### PR DESCRIPTION
_Description of changes:_

Small typo in Python getting started guide and a fix to `source-build-check.sh` in the Python template based on findings in https://github.com/aws/aws-dynamodb-encryption-python/pull/139

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
