### PR TITLE
fix(getting-started-python): remove spaces from pyenv arguement

### DIFF
--- a/getting-started/python/README.md
+++ b/getting-started/python/README.md
@@ -31,7 +31,9 @@ and how to get started developing on these projects.
     `THREADS` at a time.
     Adjust `THREADS` as appropriate for your environment.
     (ex: `tox -r -p 7`)
-
+  - `tox -e py38-accept,py38-examples,py38-integ,py38-local -p 3` :
+    Runs the listed enviorments (here, all of `py38`) with 3 workers.
+  
 - We use [`pytest`](https://docs.pytest.org/) to run our tests.
 - We use a variety of autoformatting and static analysis tools
   to ensure consistency among our projects.

--- a/getting-started/python/README.md
+++ b/getting-started/python/README.md
@@ -95,9 +95,9 @@ echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
 
 # Install latest Python versions
 for MINOR_VERSION in 2.7 3.5 3.6 3.7 3.8;do
-  PYTHON_VERSION=$(pyenv install -l | grep "^  ${MINOR_VERSION}" | tail -1)
-  pyenv install ${PYTHON_VERSION}
+  pyenv install $(pyenv install -l | grep "^  ${MINOR_VERSION}" | tail -1)
 done
+pyenv install 3.9.0
 
 # set "local" pyenv version
 #  just sets .python-version file in current directory


### PR DESCRIPTION
_Description of changes:_ 
• Described passing multiple environments to `tox` to be run in parallel, which has been very helpful to me.
• Fixed bug in `pyenv` installation script.
• Explicitly added 3.9.0 for Python 3.9. The script would fetch 3.9-dev if it was fetched the other way.

_Testing:_
Tested script locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
