### PR TITLE
fix(Python): Use ZSH instead of bsh, drop py2, add py39 & 310

### DIFF
--- a/getting-started/python/README.md
+++ b/getting-started/python/README.md
@@ -93,7 +93,7 @@ echo 'eval "$(pyenv init -)"' >> ~/.zprofile
 # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
 
 # Install latest Python versions
-for MINOR_VERSION in 3.5 3.6 3.7 3.8 3.9 3.10;do
+for MINOR_VERSION in 3.6 3.7 3.8 3.9 3.10;do
   PYTHON_VERSION=$(pyenv install -l | grep "^  ${MINOR_VERSION}" | tail -1)
   pyenv install ${PYTHON_VERSION}
 done

--- a/getting-started/python/README.md
+++ b/getting-started/python/README.md
@@ -85,14 +85,14 @@ run:
 # "install" pyenv https://github.com/pyenv/pyenv#installation
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 # bash
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
-echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
+echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
 # Install Python build dependencies
 # (varies by OS)
 # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
 
 # Install latest Python versions
-for MINOR_VERSION in 2.7 3.5 3.6 3.7 3.8;do
+for MINOR_VERSION in 3.5 3.6 3.7 3.8 3.9 3.10;do
   PYTHON_VERSION=$(pyenv install -l | grep "^  ${MINOR_VERSION}" | tail -1)
   pyenv install ${PYTHON_VERSION}
 done

--- a/getting-started/python/README.md
+++ b/getting-started/python/README.md
@@ -87,6 +87,7 @@ git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 # bash
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
 echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
+echo 'eval "$(pyenv init -)"' >> ~/.zprofile
 # Install Python build dependencies
 # (varies by OS)
 # https://github.com/pyenv/pyenv/wiki#suggested-build-environment


### PR DESCRIPTION
_Issue #, if available:_None

_Description of changes:_fix(Python): Use ZSH instead of bsh, drop py2, add py39 & 310

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
